### PR TITLE
Removed statusService as dependency from interfaceService

### DIFF
--- a/src/js/Chart/controller/overviewChartCtrl.js
+++ b/src/js/Chart/controller/overviewChartCtrl.js
@@ -4,8 +4,8 @@ angular.module('n52.core.overviewDiagram', [])
                 $scope.options = flotOverviewChartServ.options;
                 $scope.dataset = flotOverviewChartServ.dataset;
             }])
-        .factory('flotOverviewChartServ', ['timeseriesService', 'timeService', '$rootScope', 'interfaceService', 'flotDataHelperServ', 'settingsService', 'monthNamesTranslaterServ',
-            function (timeseriesService, timeService, $rootScope, interfaceService, flotDataHelperServ, settingsService, monthNamesTranslaterServ) {
+        .factory('flotOverviewChartServ', ['timeseriesService', 'statusService', 'timeService', '$rootScope', 'interfaceService', 'flotDataHelperServ', 'settingsService', 'monthNamesTranslaterServ',
+            function (timeseriesService, statusService, timeService, $rootScope, interfaceService, flotDataHelperServ, settingsService, monthNamesTranslaterServ) {
                 var options = {
                     series: {
                         downsample: {
@@ -105,11 +105,13 @@ angular.module('n52.core.overviewDiagram', [])
                 }
 
                 function loadOverViewData(tsId) {
+                    
+                    var generalizeData = statusService.status.generalizeData || false;
                     options.loading = true;
                     var ts = timeseriesService.getTimeseries(tsId);
                     if (ts) {
                         var start = options.xaxis.min, end = options.xaxis.max;
-                        interfaceService.getTsData(ts.id, ts.apiUrl, {start: start, end: end}, extendedDataRequest).then(function (data) {
+                        interfaceService.getTsData(ts.id, ts.apiUrl, {start: start, end: end}, extendedDataRequest, generalizeData).then(function (data) {
                             flotDataHelperServ.updateTimeseriesInDataSet(dataset, renderOptions, ts.internalId, data[ts.id]);
                             options.loading = false;
                         });

--- a/src/js/plugins/extendedGetTsData.js
+++ b/src/js/plugins/extendedGetTsData.js
@@ -2,13 +2,13 @@
 angular.module('n52.core.interface')
         .config(['$provide',
           function ($provide) {
-            $provide.decorator('interfaceService', ['$delegate', '$q', 'statusService', '$http', 'interfaceServiceUtils', 'utils',
-              function ($delegate, $q, statusService, $http, interfaceServiceUtils, utils) {
+            $provide.decorator('interfaceService', ['$delegate', '$q', '$http', 'interfaceServiceUtils', 'utils',
+              function ($delegate, $q, $http, interfaceServiceUtils, utils) {
                 var maxTimeExtent = moment.duration(365, 'day'), promises;
 
-                $delegate.getTsData = function (id, apiUrl, timespan, extendedData) {
+                $delegate.getTsData = function (id, apiUrl, timespan, extendedData, generalizeData) {
                   var params = {
-                    generalize: statusService.status.generalizeData || false,
+                    generalize: generalizeData || false,
                     expanded: true,
                     format: 'flot'
                   };
@@ -21,7 +21,7 @@ angular.module('n52.core.interface')
                     var start = moment(timespan.start);
                     while (start.isBefore(moment(timespan.end))) {
                       var step = moment(start).add(maxTimeExtent);
-                      var promise = $delegate.getTsData(id, apiUrl, {start: start, end: step}, extendedData);
+                      var promise = $delegate.getTsData(id, apiUrl, {start: start, end: step}, extendedData, generalizeData);
                       promises.push(promise);
                       start = step;
                     }

--- a/src/js/services/interface.js
+++ b/src/js/services/interface.js
@@ -1,6 +1,6 @@
 angular.module('n52.core.interface', [])
-        .service('interfaceService', ['$http', '$q', 'statusService', 'interfaceServiceUtils', 'utils',
-          function ($http, $q, statusService, interfaceServiceUtils, utils) {
+        .service('interfaceService', ['$http', '$q', 'interfaceServiceUtils', 'utils',
+          function ($http, $q, interfaceServiceUtils, utils) {
 
             this.getServices = function (apiUrl, id) {
               return $q(function (resolve, reject) {
@@ -115,10 +115,10 @@ angular.module('n52.core.interface', [])
               });
             };
 
-            this.getTsData = function (id, apiUrl, timespan, extendedData) {
+            this.getTsData = function (id, apiUrl, timespan, extendedData, generalizeData) {
               var params = {
                 timespan: utils.createRequestTimespan(timespan.start, timespan.end),
-                generalize: statusService.status.generalizeData || false,
+                generalize: generalizeData || false,
                 expanded: true,
                 format: 'flot'
               };

--- a/src/js/services/timeseries.js
+++ b/src/js/services/timeseries.js
@@ -26,8 +26,9 @@ angular.module('n52.core.timeseries', [])
                 }
 
                 function _loadTsData(ts) {
+                    var generalizeData = statusService.status.generalizeData || false;
                     ts.loadingData = true;
-                    interfaceService.getTsData(ts.id, ts.apiUrl, utils.createBufferedCurrentTimespan(statusService.getTime(), ts.timebuffer))
+                    interfaceService.getTsData(ts.id, ts.apiUrl, utils.createBufferedCurrentTimespan(statusService.getTime(), ts.timebuffer, generalizeData))
                             .then(function (data) {
                                 _addTsData(data, ts);
                             });


### PR DESCRIPTION
statusService is very prominent when used in a component, since it comes with many dependencies.
In interfaceService it is used merely in one function to detect whether or not data should be generalized, In order to make interfaceService more standalone statusService may be removed as dependency and its generalize attribute is added as an argument to the getData function. 
The other files have been changed accordingly.
